### PR TITLE
Patch the pkg-config directory in the gz-cmake code.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ ament_vendor(${LIB_NAME_UNDERSCORE}_vendor
   CMAKE_ARGS
     -DBUILD_DOCS:BOOL=OFF
   GLOBAL_HOOK
+  PATCHES patches
 )
 
 find_package(ament_cmake_test REQUIRED)

--- a/patches/0001-fix-pkg-config-dir.patch
+++ b/patches/0001-fix-pkg-config-dir.patch
@@ -1,0 +1,21 @@
+--- a/CMakeLists.txt	2024-03-27 17:47:47.065052145 +0000
++++ b/CMakeLists.txt	2024-03-27 17:48:31.203780798 +0000
+@@ -63,7 +63,8 @@
+ set(gz_config_install_dir "${CMAKE_INSTALL_DATAROOTDIR}/cmake/${PROJECT_NAME_LOWER}")
+ set(gz_pkgconfig_input "${CMAKE_CURRENT_SOURCE_DIR}/config/gz-cmake.pc.in")
+ set(gz_pkgconfig_output "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pc")
+-set(gz_pkgconfig_install_dir "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig")
++set(gz_pkgconfig_install_dir "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
++set(gz_pkgconfig_abs_install_dir "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig")
+ set(gz_utilities_target ${PROJECT_EXPORT_NAME}-utilities)
+ set(gz_utilities_import_target_name ${PROJECT_EXPORT_NAME}::${gz_utilities_target})
+ set(gz_utilities_target_output_filename "${gz_utilities_target}-targets.cmake")
+@@ -96,7 +97,7 @@
+ # Configure and install the pkgconfig file (needed for utilities headers)
+ file(RELATIVE_PATH
+   GZ_PC_CONFIG_RELATIVE_PATH_TO_PREFIX
+-  "${gz_pkgconfig_install_dir}"
++  "${gz_pkgconfig_abs_install_dir}"
+   "${CMAKE_INSTALL_PREFIX}"
+ )
+ 

--- a/patches/0001-fix-pkg-config-dir.patch
+++ b/patches/0001-fix-pkg-config-dir.patch
@@ -1,6 +1,24 @@
---- a/CMakeLists.txt	2024-03-27 17:47:47.065052145 +0000
-+++ b/CMakeLists.txt	2024-03-27 17:48:31.203780798 +0000
-@@ -63,7 +63,8 @@
+diff -urp gz_cmake_vendor.orig/cmake/GzPackaging.cmake gz_cmake_vendor/cmake/GzPackaging.cmake
+--- gz_cmake_vendor.orig/cmake/GzPackaging.cmake	2024-03-28 15:51:16.743283355 +0000
++++ gz_cmake_vendor/cmake/GzPackaging.cmake	2024-03-28 15:52:58.347658733 +0000
+@@ -212,10 +212,11 @@ function(_gz_create_pkgconfig)
+   endif()
+ 
+   set(pkgconfig_output "${CMAKE_BINARY_DIR}/cmake/pkgconfig/${target_name}.pc")
+-  set(pkgconfig_install_dir "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig")
++  set(pkgconfig_install_dir "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
++  set(pkgconfig_abs_install_dir "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig")
+   file(RELATIVE_PATH
+     PC_CONFIG_RELATIVE_PATH_TO_PREFIX
+-    "${pkgconfig_install_dir}"
++    "${pkgconfig_abs_install_dir}"
+     "${CMAKE_INSTALL_PREFIX}"
+   )
+ 
+diff -urp gz_cmake_vendor.orig/CMakeLists.txt gz_cmake_vendor/CMakeLists.txt
+--- gz_cmake_vendor.orig/CMakeLists.txt	2024-03-28 15:51:16.741283367 +0000
++++ gz_cmake_vendor/CMakeLists.txt	2024-03-28 15:52:12.762938969 +0000
+@@ -63,7 +63,8 @@ set(gz_version_output "${PROJECT_NAME_LO
  set(gz_config_install_dir "${CMAKE_INSTALL_DATAROOTDIR}/cmake/${PROJECT_NAME_LOWER}")
  set(gz_pkgconfig_input "${CMAKE_CURRENT_SOURCE_DIR}/config/gz-cmake.pc.in")
  set(gz_pkgconfig_output "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pc")
@@ -10,7 +28,7 @@
  set(gz_utilities_target ${PROJECT_EXPORT_NAME}-utilities)
  set(gz_utilities_import_target_name ${PROJECT_EXPORT_NAME}::${gz_utilities_target})
  set(gz_utilities_target_output_filename "${gz_utilities_target}-targets.cmake")
-@@ -96,7 +97,7 @@
+@@ -96,7 +97,7 @@ install(
  # Configure and install the pkgconfig file (needed for utilities headers)
  file(RELATIVE_PATH
    GZ_PC_CONFIG_RELATIVE_PATH_TO_PREFIX


### PR DESCRIPTION
When building on the ROS 2 buildfarm, we aren't setting some of the CMAKE_PREFIX variables.  This means that using CMAKE_INSTALL_FULL_LIBDIR actually creates a path like /opt/ros/rolling/... , which makes debuild upset.

However, we actually need the FULL_LIBDIR in order to calculate the relative path between it and the INSTALL_PREFIX. Work around this by having two variables; the
pkgconfig_install_dir (relative), used to install the files, and pkgconfig_abs_install_dir (absolute), used to calculate the relative path between them.

This should fix the build on the buildfarm.  I'll note that we are doing it here and not in gz-cmake proper because of knock-on effects to downstream gazebo.  If this is successful we may end up merging it there, at which point we can drop this patch.