### PR TITLE
Skip the IgnPython and IgnBenchmark back-compat installation.

### DIFF
--- a/patches/0002-skip-ign-backcompat.patch
+++ b/patches/0002-skip-ign-backcompat.patch
@@ -1,0 +1,39 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5047d61..7a321f6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -171,34 +171,6 @@ install(
+ 
+ message(STATUS "Install prefix: ${CMAKE_INSTALL_PREFIX}")
+ 
+-# TODO(CH3): Deprecated. Remove on tock.
+-# Install symlinks for IgnPython and IgnBenchmark
+-set(tick_tocked_cmake_files
+-  "GzPython.cmake"
+-  "GzBenchmark.cmake")
+-
+-# TODO(CH3): Deprecated. Remove on tock.
+-# Install symlinks for IgnPython and IgnBenchmark
+-foreach(cmake_file ${tick_tocked_cmake_files})
+-  string(REGEX REPLACE "^Gz" "Ign" ign_cmake_file ${cmake_file})
+-  file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/cmake")
+-
+-  if (WIN32)  # Windows requires copy instead of symlink
+-    install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E copy \
+-        ${CMAKE_INSTALL_PREFIX}\/${gz_modules_install_dir}\/${cmake_file} \
+-        ${PROJECT_BINARY_DIR}\/cmake/${ign_cmake_file})")
+-  else()
+-    install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink \
+-        ${cmake_file} \
+-        ${PROJECT_BINARY_DIR}\/cmake/${ign_cmake_file})")
+-  endif()
+-
+-  install(
+-    FILES ${PROJECT_BINARY_DIR}/cmake/${ign_cmake_file}
+-    DESTINATION ${gz_modules_install_dir}
+-    COMPONENT modules)
+-endforeach()
+-
+ include(CTest)
+ if (BUILD_TESTING)
+   add_subdirectory(test)


### PR DESCRIPTION
For reasons I don't totally understand, this doesn't work when building on Windows.  Just avoid the entire problem by not installing it here.

@azeey This is a potentially controversial patch, but it does make building this on Windows work for me.  I'm open to other ideas on how to fix this.