### PR TITLE
Fixes the cmake-config used during find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(gz_cmake_vendor)
 set(LIB_VER_MAJOR 4)
 set(LIB_VER_MINOR 0)
 set(LIB_VER_PATCH 0)
-set(LIB_VER_SUFFIX -pre1)
+set(LIB_VER_SUFFIX "-pre1")
 
 # Derived variables
 set(LIB_NAME gz-cmake)
@@ -41,7 +41,6 @@ ament_vendor(${LIB_NAME_UNDERSCORE}_vendor
   VCS_URL https://github.com/gazebosim/${GITHUB_NAME}.git
   VCS_VERSION ${GITHUB_NAME}${LIB_VER_MAJOR}_${LIB_VER}${LIB_VER_SUFFIX}
   CMAKE_ARGS
-    -DBUILD_DOCS:BOOL=OFF
   GLOBAL_HOOK
 )
 

--- a/gz-cmake-config.cmake.in
+++ b/gz-cmake-config.cmake.in
@@ -1,24 +1,3 @@
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 
 find_package(@LIB_NAME@@LIB_VER_MAJOR@ ${@LIB_NAME@_FIND_VERSION} REQUIRED COMPONENTS ${@LIB_NAME@_FIND_COMPONENTS})
-
-# Set up the core library and add it to the list of all components
-add_library(@LIB_NAME_COMP_PREFIX@::@LIB_NAME_COMP_PREFIX@ ALIAS @LIB_NAME@@LIB_VER_MAJOR@::@LIB_NAME@@LIB_VER_MAJOR@)
-add_library(@LIB_NAME_COMP_PREFIX@::core ALIAS @LIB_NAME@@LIB_VER_MAJOR@::@LIB_NAME@@LIB_VER_MAJOR@)
-
-# Retrieve the list of components
-get_target_property(components @LIB_NAME@@LIB_VER_MAJOR@::requested INTERFACE_LINK_LIBRARIES)
-
-foreach(component ${components})
-  # Skip the core library
-  if(${component} STREQUAL @LIB_NAME@@LIB_VER_MAJOR@::@LIB_NAME@@LIB_VER_MAJOR@)
-    continue()
-  endif()
-
-  # Change "gz-libN::gz-libN-component" to "component"
-  string(REGEX REPLACE "@LIB_NAME@@LIB_VER_MAJOR@::@LIB_NAME@@LIB_VER_MAJOR@-" "" component_name ${component})
-  add_library(@LIB_NAME_COMP_PREFIX@::${component_name} ALIAS ${component})
-endforeach()
-
-# Add a root gz-lib alias
-add_library(@LIB_NAME_COMP_PREFIX@ ALIAS @LIB_NAME@@LIB_VER_MAJOR@::@LIB_NAME@@LIB_VER_MAJOR@)


### PR DESCRIPTION
The provided cmake-config was not actually working if one did
```
find_package(gz_cmake_vendor)
find_package(gz-cmake)
```

This because the config file tried to create aliases to targets that don't exist. For example, gz-cmake4::gz-cmake4 is not exported by gz-cmake.