### PR TITLE
Fix next version number to 0.2.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,13 +2,10 @@
 Changelog for package gz_cmake_vendor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.3.2 (2025-09-04)
+0.2.3 (2025-09-04)
 ------------------
 * Bump version to 4.2.0 (`#17 <https://github.com/gazebo-release/gz_cmake_vendor/issues/17>`_)
 * Contributors: Addisu Z. Taddese
-
-0.3.0 (2025-04-28)
-------------------
 
 0.2.2 (2025-02-26)
 ------------------

--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,7 @@
     To avoid any confusion with the version of the vendor package, the major
     version here will always be 0.
   -->
-  <version>0.3.2</version>
+  <version>0.2.3</version>
   <description>
     Vendor package for: gz-cmake4 4.2.0
 


### PR DESCRIPTION
I saw 0.3.0 in the changelog and assumed that it was released into kilted, but I think what happened was that the minor version number was bumped on rolling and then kilted was branched off. So even though the changelog shows there was a 0.3.0, that version was only released into rolling, not into kilted. Checking `apt-cache show ros-kilted-gz-cmake-vendor` shows that the last release was 0.2.2.

Even though I just tagged 0.3.2, the plan is to make another release (0.2.3) so that all kilted versions are 0.2.*. I had bloom-released 0.3.2, but closed the rosdep PR (https://github.com/ros/rosdistro/pull/47523).

When we are ready for the next rolling release, we'll need to make sure it's 0.3.3. I don't want to delete the 0.3.2 tag just in case there are tools out there that get triggered when we tag commits.

cc @j-rivero 